### PR TITLE
Improve .es domains

### DIFF
--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -389,15 +389,15 @@ $additionaldomainfields[".no"] = $additionaldomainfields[".ro"];
 
 // .ES
 $additionaldomainfields[".es"][] = array(
-    "Name" => "Identification type",
+    "Name" => "Tipo de identificación",
     "LangVar" => "esIdentificationType",
-    "Options" => "companyRegistrationNumber|CIF/NIF (Company Registration Number),socialSecurityNumber|Número Seguridad Social (Social Security Number),passportNumber|Pasaporte/DNI (Passport Number)",
+    "Options" => "passportNumber|DNI (Si es un particular),companyRegistrationNumber|CIF (Si es una empresa)",
     "Type" => "dropdown",
     "op_dropdown_for_op_name" => "esIdentificationNumber"
 );
 
 $additionaldomainfields['.es'][] = array(
-    'Name' => 'Identification number',
+    'Name' => 'Número de identificación',
     "Type" => "text",
     "Size" => "30",
     "Required" => true,


### PR DESCRIPTION
I think that the logical thing is that the .es are adapted to the real use in Spain, the best method is that it is translated as I indicate below. It works for me and it is easier for Spanish clients.