### PR TITLE
[hotfix] remove variable type

### DIFF
--- a/modules/registrars/openprovider/Models/Tld.php
+++ b/modules/registrars/openprovider/Models/Tld.php
@@ -6,7 +6,10 @@ namespace OpenProvider\WhmcsRegistrar\Models;
 
 class Tld
 {
-    private string $tld;
+    /**
+     * @var string
+     */
+    private $tld;
 
     public function __construct(string $tld)
     {


### PR DESCRIPTION
Its my wrong

I accidentally inputted the type of the variable in the class. In php, variable types are not provided.