### PR TITLE
Update DomainSync.php

### DIFF
--- a/modules/registrars/openprovider/src/DomainSync.php
+++ b/modules/registrars/openprovider/src/DomainSync.php
@@ -289,7 +289,7 @@ class DomainSync
     protected function process_next_due_dates()
     {
         $this->printDebug('PROCESSING NEXT DUE DATES SYNC FOR ALL OP DOMAINS');
-        $days_before_expiry_date = Configuration::getOrDefault('nextDueDateOffset',14);
+        $days_before_expiry_date = Configuration::getOrDefault('nextDueDateOffset',0);
         $nextDueDateUpdateMaxDayDifference = Configuration::getOrDefault('nextDueDateUpdateMaxDayDifference', 100);
 
         $updated_domains = $this->domain->updateNextDueDateOffset($days_before_expiry_date, $nextDueDateUpdateMaxDayDifference, 'openprovider');


### PR DESCRIPTION
With the latest versions of the module the nextDueDateOffset cannot be 0. This is parsed as an empty integer and thus defaulted to 14 days. This is not according to the documentation when in case the nextDueDateOffset is not set, but updateNextDueDate is, it will update the value equal to the expiry date.

https://github.com/openprovider/OP-WHMCS7/blob/master/docs/configure_openprovider_cron_sync.md